### PR TITLE
Add docker-compose for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+docker-compose.yml
+./dev/Dockerfile
+dist
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@
 
 This is the Example Package for OS.js.
 
+## Development
+
+Easily run the application using `docker-compose`:
+
+```bash
+docker compose up
+```
+
+This will run an instance of `OSJS` on port 8000 with your application added to it. Every time anything changes inside the application source code, application will be built with new changes and added inside `OSJS` again.
+
+Also, `config.js` inside `dev` folder is replaced by the `src/server/config.js` inside `OSJS`. If your app requires any specific options based on `config.js`, feel free to add your options and expect `OSJS` to be restarted and considering your options!
+
 ## Installation
 
 ```bash

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,18 @@
+FROM osjs/osjs
+
+WORKDIR /usr/src/osjs
+
+RUN npm i -g watch-cli
+
+COPY ./package.json ./src/packages/osjs-example-application/package.json
+RUN cd ./src/packages/osjs-example-application && npm i
+
+COPY ./dev/start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+COPY . ./src/packages/osjs-example-application/
+RUN cd ./src/packages/osjs-example-application && npm run build
+
+RUN npm run package:discover
+
+CMD ["./start.sh"]

--- a/dev/config.js
+++ b/dev/config.js
@@ -1,0 +1,46 @@
+/*
+ * OS.js - JavaScript Cloud/Web Desktop Platform
+ *
+ * Copyright (c) 2011-2020, Anders Evenrud <andersevenrud@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author  Anders Evenrud <andersevenrud@gmail.com>
+ * @licence Simplified BSD License
+ */
+
+//
+// This is the server configuration tree.
+// Guide: https://manual.os-js.org/config/#server
+// Complete config tree: https://github.com/os-js/osjs-server/blob/master/src/config.js
+//
+
+// This file will be placed as src/server/config.js
+
+const path = require('path');
+const root = path.resolve(__dirname, '../../');
+
+module.exports = {
+  root,
+  port: 8000,
+  public: path.resolve(root, 'dist'),
+};

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -1,0 +1,5 @@
+APP_NAME="osjs-example-application"
+
+(cd ./src/packages/$APP_NAME && npm run watch) \
+& (npx nodemon --ignore 'dist/**/*' --watch package-lock.json --watch src/server --watch package.json --watch src/packages src/server/index.js) \
+& (watch -p "./src/packages/$APP_NAME/metadata.json" -c "npm run package:discover")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  osjs:
+    build:
+      context: .
+      dockerfile: ./dev/Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/usr/src/osjs/src/packages/osjs-example-application
+      - ./dev/config.js:/usr/src/osjs/src/server/config.js
+      - /usr/src/osjs/src/packages/osjs-example-application/node_modules


### PR DESCRIPTION
Hi,

This PR will add a `docker-compose.yml` for local development. It is best if anyone could see their application right inside the OSJS when they are developing their app, and changes were live. So I added a `docker-compose` to achieve so. Also, everyone can see a demo of others' apps with only one command (`docker compose up`).